### PR TITLE
Upgrade Ruby version + install necessary gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,9 @@ USER root
 WORKDIR /build
 COPY . /build
 
+RUN gem update \
+    && gem install concurrent-ruby \
+    && bundle install
+
 WORKDIR /
 ENTRYPOINT [ "/build/bin/wayback_machine_downloader" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-alpine
+FROM ruby:3.1.6-alpine
 USER root
 WORKDIR /build
 COPY . /build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Wayback Machine Downloader
-
-![version](https://img.shields.io/badge/version-2.3.3-green.svg)
+[![version](https://badge.fury.io/rb/wayback_machine_downloader_straw.svg)](https://rubygems.org/gems/wayback_machine_downloader_straw)
 
 This is a fork of the [Wayback Machine Downloader](https://github.com/hartator/wayback-machine-downloader). With this, you can download a website from the Internet Archive Wayback Machine.
 


### PR DESCRIPTION
- Upgraded Ruby image version to 3.1.6. 
- Install concurrent-ruby gem in Docker at build time to avoid errors like cannot load such file -- concurrent-ruby