### PR TITLE
Increase performance of  Bundler processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM ruby:3.4.3-alpine
 USER root
 WORKDIR /build
-COPY . /build
+
+COPY Gemfile /build/
+COPY *.gemspec /build/
 
 RUN gem update \
-    && gem install concurrent-ruby \
+    && bundle config set jobs $(nproc) \
     && bundle install
+
+COPY . /build
 
 WORKDIR /
 ENTRYPOINT [ "/build/bin/wayback_machine_downloader" ]


### PR DESCRIPTION
Additional modification based on 77998372cb6f4252433564afb08f132d7d7bd344: **there is no need to install Ruby gems from Dockerfile.**
**Before the changes** in gemspec file (look for: 77998372cb6f4252433564afb08f132d7d7bd344), **the application was initialized before the necessary Gems were loaded.** 
That causes errors like "`cannot load such file -- concurrent-ruby`" during the Docker build process