### PR TITLE
Using ghcr.io for pulling Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ docker build -t wayback_machine_downloader .
 docker run -it --rm wayback_machine_downloader [options] URL
 ```
 
+or the example without cloning the repo - fetching smallrockets.com until the year 2013:
+
+```bash
+docker run -v .:/websites ghcr.io/strawberrymaster/wayback-machine-downloader:master wayback_machine_downloader --to 20130101 smallrockets.com
+```
+
 ### 🐳 Using Docker Compose
 
 We can also use it with Docker Compose, which provides a lot of benefits for extending more functionalities (such as implementing storing previous downloads in a database):


### PR DESCRIPTION
A description on how to **use ghcr.io** was added to the Readme file. The official GitHub container registry provides an easy way **to get Docker images directly from GitHub repositories.**