### PR TITLE
Fix bug with archive urls containing square brackets

### DIFF
--- a/lib/wayback_machine_downloader.rb
+++ b/lib/wayback_machine_downloader.rb
@@ -721,6 +721,9 @@ class WaybackMachineDownloader
         "https://web.archive.org/web/#{file_timestamp}id_/#{file_url}"
       end
 
+      # Escape square brackets because they are not valid in URI()
+      wayback_url = wayback_url.gsub('[', '%5B').gsub(']', '%5D')
+
       request = Net::HTTP::Get.new(URI(wayback_url))
       request["Connection"] = "keep-alive"
       request["User-Agent"] = "WaybackMachineDownloader/#{VERSION}"


### PR DESCRIPTION
The script currently fails if the original URL being downloaded contains square brackets (`[` or `]`).

```bash
ruby bin/wayback_machine_downloader -d ./tmp/ -e "https://www.bitchmedia.org/sites/default/files/styles/120x120_square_thumb/public/images/profile_photos/10406373_10101103381880685_927555188512019327_n[1].jpg"
Downloading https://www.bitchmedia.org/sites/default/files/styles/120x120_square_thumb/public/images/profile_photos/10406373_10101103381880685_927555188512019327_n[1].jpg to ./tmp/ from Wayback Machine archives.
Getting snapshot pages from Wayback Machine API...
. found 1 snapshots.
Saved snapshot list to ./tmp/.cdx.json

1 files found matching criteria.
1 files to download:
2025-06-03 16:34:42 [WARN] Retry 1/3 for https://www.bitchmedia.org/sites/default/files/styles/120x120_square_thumb/public/images/profile_photos/10406373_10101103381880685_927555188512019327_n[1].jpg: bad URI (is not URI?): "https://web.archive.org/web/20220628201214id_/https://www.bitchmedia.org/sites/default/files/styles/120x120_square_thumb/public/images/profile_photos/10406373_10101103381880685_927555188512019327_n[1].jpg"
2025-06-03 16:34:44 [WARN] Retry 2/3 for https://www.bitchmedia.org/sites/default/files/styles/120x120_square_thumb/public/images/profile_photos/10406373_10101103381880685_927555188512019327_n[1].jpg: bad URI (is not URI?): "https://web.archive.org/web/20220628201214id_/https://www.bitchmedia.org/sites/default/files/styles/120x120_square_thumb/public/images/profile_photos/10406373_10101103381880685_927555188512019327_n[1].jpg"
```

This PR escapes square brackets and then it works:
```bash
ruby bin/wayback_machine_downloader -d ./tmp/ -e "https://www.bitchmedia.org/sites/default/files/styles/120x120_square_thumb/public/images/profile_photos/10406373_10101103381880685_927555188512019327_n[1].jpg"
Downloading https://www.bitchmedia.org/sites/default/files/styles/120x120_square_thumb/public/images/profile_photos/10406373_10101103381880685_927555188512019327_n[1].jpg to ./tmp/ from Wayback Machine archives.
Getting snapshot pages from Wayback Machine API...
. found 1 snapshots.
Saved snapshot list to ./tmp/.cdx.json

1 files found matching criteria.
1 files to download:
https://www.bitchmedia.org/sites/default/files/styles/120x120_square_thumb/public/images/profile_photos/10406373_10101103381880685_927555188512019327_n[1].jpg -> ./tmp/sites/default/files/styles/120x120_square_thumb/public/images/profile_photos/10406373_10101103381880685_927555188512019327_n[1].jpg (1/1)

Download finished in 3.43s.
Results saved in ./tmp/
Cleaning up state files...
```

It's possible other reserved characters like `{}|^` could cause similar problems and need to be escaped too but I didn't have any handy to test and wasn't sure.