### PR TITLE
Fix Docker command volume mount path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ docker run -it --rm wayback_machine_downloader [options] URL
 As an example of how this works without cloning this repo, this command fetches smallrockets.com until the year 2013:
 
 ```bash
-docker run -v .:/websites ghcr.io/strawberrymaster/wayback-machine-downloader:master wayback_machine_downloader --to 20130101 smallrockets.com
+docker run -v .:/build/websites ghcr.io/strawberrymaster/wayback-machine-downloader:master wayback_machine_downloader --to 20130101 smallrockets.com
 ```
 
 ### 🐳 Using Docker Compose


### PR DESCRIPTION
I don't yet have a grasp on the entirety of this project, but this change…
- made some files appear (contrary to the unmodified volume mount)
- seems to be in line with other parts of the README.

For reference, the example command was introduced in 13e88ce04a872528e0256264dff6199b5c819a4e.